### PR TITLE
Fix issue #17. SwiftLint cause the shell script error.

### DIFF
--- a/OnixFirebaseChat/OnixFirebaseChat.xcodeproj/project.pbxproj
+++ b/OnixFirebaseChat/OnixFirebaseChat.xcodeproj/project.pbxproj
@@ -359,7 +359,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint lint --strict || exit 3\nelse\necho \"SwiftLint does not exist\" >&2\nexit 1\nfi";
+			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed\"\nfi";
 		};
 		47F2CDC93D50B2D409097AFF /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Issue was solved by removing "exit 3" from the script code.